### PR TITLE
Remove dates from PRC notebook names

### DIFF
--- a/jupyter-covid19/Dockerfile
+++ b/jupyter-covid19/Dockerfile
@@ -17,10 +17,10 @@ ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-noteb
 RUN touch /home/jovyan/covid19-notebook/requirements.txt
 
 # copy premade notebooks
-ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/jhu-summary-overview/COVID-19-JHU_data_analysis_04072020.ipynb /home/jovyan/covid19-notebook/
+ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/jhu-summary-overview/COVID-19-JHU_data_analysis.ipynb /home/jovyan/covid19-notebook/
 RUN touch /home/jovyan/covid19-notebook/COVID-19-JHU_data_analysis.ipynb
 
-ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/kaggle-demographics/kaggle_data_analysis_04072020.ipynb /home/jovyan/covid19-notebook/
+ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/kaggle-demographics/kaggle_data_analysis.ipynb /home/jovyan/covid19-notebook/
 RUN touch /home/jovyan/covid19-notebook/kaggle_data_analysis.ipynb
 
 ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/chicago-seir-forecast/covid19_seir.ipynb /home/jovyan/covid19-notebook/
@@ -32,10 +32,10 @@ RUN touch /home/jovyan/covid19-notebook/seir_diagram.png
 ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/ctp_testing/CTP_testing.ipynb /home/jovyan/covid19-notebook/
 RUN touch /home/jovyan/covid19-notebook/CTP_testing.ipynb
 
-ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/TCGA_OV_COVID_0722.ipynb /home/jovyan/covid19-notebook/
+ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/TCGA_OV_COVID.ipynb /home/jovyan/covid19-notebook/
 RUN touch /home/jovyan/covid19-notebook/TCGA_OV_COVID.ipynb
 
-ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/symptoms_and_fatality_covid19_0722.ipynb /home/jovyan/covid19-notebook/
+ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/symptoms_and_fatality_covid19.ipynb /home/jovyan/covid19-notebook/
 RUN touch /home/jovyan/covid19-notebook/symptoms_and_fatality_covid19.ipynb
 
 ADD https://raw.githubusercontent.com/uc-cdis/covid19-tools/master/covid19-notebooks/SSR/SSR_notebook.ipynb /home/jovyan/covid19-notebook/


### PR DESCRIPTION
Fix errors "Notebook does not appear to be JSON" when opening notebooks because of messed up links
see https://github.com/uc-cdis/covid19-tools/pull/144
