### PR TITLE
feat(stata): add jupyter notebook container with stata install logic

### DIFF
--- a/.github/workflows/push_stata_image.yml
+++ b/.github/workflows/push_stata_image.yml
@@ -1,0 +1,51 @@
+name: Push Stata Image to quay
+
+on:
+  push:
+    paths:
+      - jupyter-pystata/**
+      - .github/workflows/push_stata_image.yml
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 30000
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+      - uses: actions/checkout@v2
+      - uses: prewk/s3-cp-action@master
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE: 's3://ctds-stata/Stata17Linux64.tar.gz'
+          DEST: './jupyter-pystata/resources/'
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-output name=branch::$(echo $(echo ${GITHUB_REF#refs/heads/} | tr / _))"
+        id: extract_branch
+
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: stata-heal
+          tags: ${{ steps.extract_branch.outputs.branch }} ${{ github.sha }}
+          dockerfiles: ./jupyter-pystata/Dockerfile
+
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/cdis
+          username: ${{ secrets.QUAY_SERVICE_ACCOUNT_USER }}
+          password: ${{ secrets.QUAY_SERVICE_ACCOUNT_PASSWORD }}

--- a/jupyter-pystata/.gitignore
+++ b/jupyter-pystata/.gitignore
@@ -1,0 +1,1 @@
+Stata17Linux64.tar.gz

--- a/jupyter-pystata/Dockerfile
+++ b/jupyter-pystata/Dockerfile
@@ -1,0 +1,32 @@
+FROM quay.io/cdis/jupyter-notebook:1.1.0
+
+USER root
+RUN apt-get update
+
+# needed if user wants to run stinit (license validation) in the workspace
+RUN	apt-get install -y libncurses5
+
+RUN mkdir /usr/local/stata17
+COPY jupyter-pystata/resources/Stata17Linux64.tar.gz /tmp/Stata17Linux64.tar.gz
+RUN cd /usr/local/stata17 && tar -xvf /tmp/Stata17Linux64.tar.gz
+
+RUN chown $NB_USER /usr/local/stata17/
+ENV PATH $PATH:/usr/local/stata17
+RUN cd /usr/local/stata17 && \
+	{ echo y; echo y; echo y; } | ./install
+
+COPY jupyter-pystata/resources/Stata.ipynb $NB_WORKDIR
+
+# Allow notebook to run withing an <iframe/>
+RUN echo "c.NotebookApp.tornado_settings = {\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self'\"}}" \
+	>> /home/$NB_USER/.jupyter/jupyter_notebook_config.py
+
+# When an iPython session starts, check the ~/pd/ directory for a stata.lic license file and copy if present
+RUN mkdir -p /home/$NB_USER/.ipython \
+			 /home/$NB_USER/.ipython/profile_default/ \
+			 /home/$NB_USER/.ipython/profile_default/startup/
+COPY jupyter-pystata/resources/copy_license_on_startup.py \
+	/home/$NB_USER/.ipython/profile_default/startup/copy_license_on_startup.py
+
+USER $NB_USER
+RUN pip install --user stata_setup

--- a/jupyter-pystata/README.md
+++ b/jupyter-pystata/README.md
@@ -1,0 +1,26 @@
+## Stata Workspaces
+
+---
+
+### About
+ Stata is a proprietary statistical computing language with many research applications. Gen3 Stata workspaces support Stata17 through Jupyter notebooks and Stata's [Python interoperability package](https://pypi.org/project/stata-setup/).
+
+### Images
+Since Stata is proprietary software, we do not include any of its components under version control, but instead under a protected S3 bucket. This requires that our images not be built with standard Quay hooks, but rather with a Github workflow, `push_stata_image`, which bundles Stata software into an image and pushes it to `stata-heal:{branch}` on Quay.
+
+Note: While we have received permission from Stata to keep these containers public in keeping with our usual practices, the Stata software bundled in these containers should not be used for any purpose outside of our Gen3 workspaces. If you need access to Stata, please reach out to them directly at www.stata.com.
+
+
+### Licensing
+Stata software requires a license to run. As a one-time step, workspace users should add their license files in their persistant workspace storage as `~/pd/stata.lic` . This file is checked via an iPython startup hook (triggered when a new notebook is opened) and copied to the appropriate location so that Stata can recognize it.
+
+### Local development
+To build, enter the root directory of this repo and run:
+```
+docker build -t stata -f jupyter-pystata/Dockerfile .
+```
+
+and to run this container:
+```
+docker run -P 8888:8888 stata
+```

--- a/jupyter-pystata/resources/Stata.ipynb
+++ b/jupyter-pystata/resources/Stata.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import stata_setup\n",
+    "stata_setup.config(\"/usr/local/stata17\", \"mp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%stata\n",
+    ". describe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%mata\n",
+    "sqrt(4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/jupyter-pystata/resources/copy_license_on_startup.py
+++ b/jupyter-pystata/resources/copy_license_on_startup.py
@@ -1,0 +1,6 @@
+import os.path
+import os
+import shutil
+
+if os.path.isfile(f"/home/{os.environ['NB_USER']}/pd/stata.lic"):
+	shutil.copyfile(f"/home/{os.environ['NB_USER']}/pd/stata.lic", "/usr/local/stata17/stata.lic")


### PR DESCRIPTION
### New Features
- Adds a container for a jupyter workspace with Stata functionality
  - Stata workspaces have Stata software pre-installed but unlicensed. Users can bring licenses and leave them in their `~/pd/` directories

### Deployment changes
- The `stata-heal` image on quay is built and pushed via github workflow in order to leverage github secrets to keep the Stata software privately hosted in s3 (as opposed to other containers which are built via quay github hooks)