### PR TITLE
Add `compliant_anibali_pytorch` Dockerfile

### DIFF
--- a/nextflow-base-images/compliant_anibali_pytorch/Dockerfile
+++ b/nextflow-base-images/compliant_anibali_pytorch/Dockerfile
@@ -1,0 +1,15 @@
+# Use the specified base image
+FROM anibali/pytorch:1.13.1-cuda11.7-ubuntu22.04
+
+# Change the USER to `root` to have necessary privileges to perform apt-get commands
+USER root
+RUN apt-get update && apt-get -y upgrade
+
+# Upgrade pillow to the latest stable version
+RUN pip install --upgrade pillow
+
+# install openssl 3.0.8 as it is required for FIPS compliance.
+RUN mamba install -yc conda-forge openssl=3.0.8
+
+# Change USER back to the one in the anibali image to limit privileges
+USER user


### PR DESCRIPTION
Jira Ticket: [MIDRC-510](https://ctds-planx.atlassian.net/browse/MIDRC-510)

### New Features
- Add Nextflow base image based on `anibali/pytorch:1.13.1-cuda11.7-ubuntu22.04` with a fix to all the critical vulnerabilities for FIPS

[MIDRC-510]: https://ctds-planx.atlassian.net/browse/MIDRC-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ