### PR TITLE
Replace `tag_name`  with `image uri`

### DIFF
--- a/.github/workflows/get_layer_info_for_nf_imgs.yml
+++ b/.github/workflows/get_layer_info_for_nf_imgs.yml
@@ -27,7 +27,7 @@ jobs:
               tag_name=$(echo ${image_url} | sed 's|\(.*\):\(.*\)|\2|')
               echo $manifest_url, $tag_name
               response=$(curl -s -H "Authorization: Bearer $TOKEN" $manifest_url | jq "[.layers[].digest]")
-              layer_json=$(echo "$layer_json" | jq --arg key "$tag_name" --argjson extracted "$response" '. + { ($key): $extracted }')
+              layer_json=$(echo "$layer_json" | jq --arg key "$image_url" --argjson extracted "$response" '. + { ($key): $extracted }')
           done <<< "$url_list"
           echo "$layer_json" > nextflow-base-images/approved_img_layers.json
       - name: Commit and push changes


### PR DESCRIPTION
Link to JIRA ticket if there is one: [MIDRC-688](https://ctds-planx.atlassian.net/browse/MIDRC-688)

### Improvements
* Replace `tag_name` with `image_uri` to give more context to users when image scanning pipeline fails

[MIDRC-688]: https://ctds-planx.atlassian.net/browse/MIDRC-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ