### PR TITLE
Update GH workflow to process `allowed_base_images.txt`

### DIFF
--- a/.github/workflows/get_layer_info_for_nf_imgs.yml
+++ b/.github/workflows/get_layer_info_for_nf_imgs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Pull HTTP Response
         run: |
-          url_list=$(curl -s "https://raw.githubusercontent.com/uc-cdis/containers/master/nextflow-base-images/allowed_base_images.txt")
+          url_list=$(curl -s "https://raw.githubusercontent.com/uc-cdis/containers/chore/update_reading_allowed_base_images_txt/nextflow-base-images/allowed_base_images.txt")
           TOKEN=$(curl -s https://public.ecr.aws/token/ | jq -r .token)
           layer_json="{}"
           while IFS= read -r image_url; do

--- a/.github/workflows/get_layer_info_for_nf_imgs.yml
+++ b/.github/workflows/get_layer_info_for_nf_imgs.yml
@@ -24,10 +24,12 @@ jobs:
           while IFS= read -r image_url; do
             # Ignore lines that start with #
               if [[ "$image_url" == \#* ]]; then
+                echo "Skipping this line -- $image_url"
                 continue
               fi
             # Strip the first * if a line starts with *
               if [[ "$image_url" == \** ]]; then
+                echo "Stripping * from this line -- $image_url"
                 image_url="${image_url:1}"
               fi
               manifest_url=$(echo ${image_url} | sed 's|public\.ecr\.aws/\(.*\):\(.*\)|https://public.ecr.aws/v2/\1/manifests/\2|')

--- a/.github/workflows/get_layer_info_for_nf_imgs.yml
+++ b/.github/workflows/get_layer_info_for_nf_imgs.yml
@@ -3,7 +3,7 @@ on:
   # Primarily this workflow is only expected to be triggered by `build_and_push_nf_base_images.yml`, these extra triggers are just added for convenience.
   workflow_dispatch:
   push:
-    branches: master
+    # branches: master
     paths:
       - 'nextflow-base-images/**'
       - '.github/workflows/get_layer_info_for_nf_imgs.yml'
@@ -22,6 +22,14 @@ jobs:
           TOKEN=$(curl -s https://public.ecr.aws/token/ | jq -r .token)
           layer_json="{}"
           while IFS= read -r image_url; do
+            # Ignore lines that start with #
+              if [[ "$image_url" == \#* ]]; then
+                continue
+              fi
+            # Strip the first * if a line starts with *
+              if [[ "$image_url" == \** ]]; then
+                image_url="${image_url:1}"
+              fi
               manifest_url=$(echo ${image_url} | sed 's|public\.ecr\.aws/\(.*\):\(.*\)|https://public.ecr.aws/v2/\1/manifests/\2|')
               tag_name=$(echo ${image_url} | sed 's|\(.*\):\(.*\)|\2|')
               echo $manifest_url, $tag_name

--- a/.github/workflows/get_layer_info_for_nf_imgs.yml
+++ b/.github/workflows/get_layer_info_for_nf_imgs.yml
@@ -3,7 +3,7 @@ on:
   # Primarily this workflow is only expected to be triggered by `build_and_push_nf_base_images.yml`, these extra triggers are just added for convenience.
   workflow_dispatch:
   push:
-    # branches: master
+    branches: master
     paths:
       - 'nextflow-base-images/**'
       - '.github/workflows/get_layer_info_for_nf_imgs.yml'
@@ -18,7 +18,7 @@ jobs:
 
       - name: Pull HTTP Response
         run: |
-          url_list=$(curl -s "https://raw.githubusercontent.com/uc-cdis/containers/chore/update_reading_allowed_base_images_txt/nextflow-base-images/allowed_base_images.txt")
+          url_list=$(curl -s "https://raw.githubusercontent.com/uc-cdis/containers/master/nextflow-base-images/allowed_base_images.txt")
           TOKEN=$(curl -s https://public.ecr.aws/token/ | jq -r .token)
           layer_json="{}"
           while IFS= read -r image_url; do

--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,6 +1,4 @@
-#this is a comment line, trying to see if this line is being ignored
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
-#Also adding an asterisk before the name of the image, to test if the `*` is being ignored by the script
-*public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
+public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl

--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,3 +1,4 @@
+#this is a comment line, trying to see if this line is being ignored
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl

--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,3 +1,4 @@
+# Note that base images with an asterisk `*` are temporarily unavailable for use and are being updated.
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl

--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,5 +1,6 @@
 #this is a comment line, trying to see if this line is being ignored
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
-public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
+#Also adding an asterisk before the name of the image, to test if the `*` is being ignored by the script
+*public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl


### PR DESCRIPTION
Link to JIRA ticket if there is one:  [MIDRC-741](https://ctds-planx.atlassian.net/browse/MIDRC-741)

### New Features
* Update GH workflow `get_layer_info_for_nf_imgs.yml` to process `#` and `*` in the `allowed_base_images.txt` file


[MIDRC-741]: https://ctds-planx.atlassian.net/browse/MIDRC-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ