### PR TITLE
CUDA images are unavailable temporarily

### DIFF
--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,5 +1,5 @@
 # Note that base images with an asterisk `*` are temporarily unavailable for use and are being updated.
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
-public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
-public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
-public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl
+* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
+* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
+* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl


### PR DESCRIPTION
add asterisk to the CUDA-based images to indicate to users they are not available for use. 
See this slack conversation - https://cdis.slack.com/archives/C0552E6EAM7/p1723564616687449

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
