### PR TITLE
Update allowed_base_images.txt - remove asterisks

### DIFF
--- a/nextflow-base-images/allowed_base_images.txt
+++ b/nextflow-base-images/allowed_base_images.txt
@@ -1,5 +1,5 @@
 # Note that base images with an asterisk `*` are temporarily unavailable for use and are being updated.
 public.ecr.aws/u5x5h6w3/nextflow-approved/public:amazonlinux-base
-* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
-* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
-* public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl
+public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-11.8-ubuntu22.04-openssl
+public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-ubuntu22.04-openssl
+public.ecr.aws/u5x5h6w3/nextflow-approved/public:gen3-cuda-12.3-torch2.2-ubuntu22.04-openssl


### PR DESCRIPTION
removing asterisks because the images are functional again -- see this slack conversation: https://cdis.slack.com/archives/C0552E6EAM7/p1727203753737159